### PR TITLE
Auto exposure and white balance loop: scale per-channel rgb gains so none exceed new parameter rgb_gain_limit

### DIFF
--- a/source/application/lua_libraries/camera.c
+++ b/source/application/lua_libraries/camera.c
@@ -50,7 +50,7 @@ static struct camera_auto_last_values
     double green_gain;
     double blue_gain;
 } last = {
-    .shutter = 4096.0f,
+    .shutter = 1600.0f,
     .analog_gain = 1.0f,
     .red_gain = 121.6f,
     .green_gain = 64.0f,
@@ -800,6 +800,10 @@ static int lua_camera_auto(lua_State *L)
                                 ? matrix_g / last.green_gain
                                 : matrix_b / last.blue_gain);
 
+    // scale normalized RGB values to the gain scale
+    max_rgb *= 256.0;
+
+    // target per-channel gains that we blend towards
     double red_gain = max_rgb / matrix_r * last.red_gain;
     double green_gain = max_rgb / matrix_g * last.green_gain;
     double blue_gain = max_rgb / matrix_b * last.blue_gain;

--- a/source/application/lua_libraries/camera.c
+++ b/source/application/lua_libraries/camera.c
@@ -50,7 +50,7 @@ static struct camera_auto_last_values
     double green_gain;
     double blue_gain;
 } last = {
-    .shutter = 1600.0f,
+    .shutter = 4096.0f,
     .analog_gain = 1.0f,
     .red_gain = 121.6f,
     .green_gain = 64.0f,
@@ -561,12 +561,12 @@ static int lua_camera_auto(lua_State *L)
     }
 
     // Default auto exposure settings
-    camera_metering_mode_t metering = AVERAGE;
-    double target_exposure = 0.18;
-    double exposure_speed = 0.50;
-    double shutter_limit = 3072.0;
+    camera_metering_mode_t metering = CENTER_WEIGHTED;
+    double target_exposure = 0.1;
+    double exposure_speed = 0.45;
+    double shutter_limit = 16383.0;
     double analog_gain_limit = 16.0;
-    double rgb_gain_limit = 141.0;
+    double rgb_gain_limit = 287.0;
 
     // Default white balance settings
     double white_balance_speed = 0.5;

--- a/source/application/lua_libraries/camera.c
+++ b/source/application/lua_libraries/camera.c
@@ -564,7 +564,7 @@ static int lua_camera_auto(lua_State *L)
     camera_metering_mode_t metering = AVERAGE;
     double target_exposure = 0.18;
     double exposure_speed = 0.50;
-    double shutter_limit = 8192.0;
+    double shutter_limit = 3072.0;
     double analog_gain_limit = 16.0;
     double rgb_gain_limit = 141.0;
 


### PR DESCRIPTION
Per-channel (r, g, b) gains seem to contribute most to the row noise that presents in (rotated) images as vertical lines.
Rather than use the full range of r, g, b gain (0..1023), allow users of the auto exposure and white balance algorithm to set a cap on the rgb gain, and set a default on the low end of that range (141).