### PR TITLE
Pairing flow

### DIFF
--- a/source/application/bluetooth.c
+++ b/source/application/bluetooth.c
@@ -332,6 +332,8 @@ void SD_EVT_IRQHandler(void)
                     bond_storage,
                     (uint32_t *)&bond.keyset.keys_own.p_enc_key->enc_info,
                     sizeof(bond.keyset.keys_own.p_enc_key->enc_info));
+
+                status = show_pairing_screen(true);
             }
 
             break;

--- a/source/application/bluetooth.c
+++ b/source/application/bluetooth.c
@@ -333,7 +333,7 @@ void SD_EVT_IRQHandler(void)
                     (uint32_t *)&bond.keyset.keys_own.p_enc_key->enc_info,
                     sizeof(bond.keyset.keys_own.p_enc_key->enc_info));
 
-                status = show_pairing_screen(true);
+                status = show_pairing_screen(true, false);
             }
 
             break;

--- a/source/application/lua_libraries/camera.c
+++ b/source/application/lua_libraries/camera.c
@@ -561,12 +561,12 @@ static int lua_camera_auto(lua_State *L)
     }
 
     // Default auto exposure settings
-    camera_metering_mode_t metering = AVERAGE;
-    double target_exposure = 0.18;
-    double exposure_speed = 0.50;
-    double shutter_limit = 3072.0;
+    camera_metering_mode_t metering = CENTER_WEIGHTED;
+    double target_exposure = 0.1;
+    double exposure_speed = 0.45;
+    double shutter_limit = 16383.0;
     double analog_gain_limit = 16.0;
-    double rgb_gain_limit = 141.0;
+    double rgb_gain_limit = 287.0;
 
     // Default white balance settings
     double white_balance_speed = 0.5;

--- a/source/application/lua_libraries/system.c
+++ b/source/application/lua_libraries/system.c
@@ -36,6 +36,12 @@
 
 static int lua_update(lua_State *L)
 {
+    int status = show_pairing_screen(false, true);
+    if (status != LUA_OK)
+    {
+        const char *lua_error = lua_tostring(L, -1);
+        luaL_error(L, "%s", lua_error);
+    }
     check_error(sd_power_gpregret_set(0, 0xB1));
     NVIC_SystemReset();
     return 0;

--- a/source/application/luaport.c
+++ b/source/application/luaport.c
@@ -63,14 +63,19 @@ void lua_break_signal_interrupt(void)
                 1);
 }
 
-int show_pairing_screen(bool is_paired)
+int show_pairing_screen(bool is_paired, bool is_update)
 {
     int status;
     if(L_global == NULL)
     {
         return LUA_ERRRUN;
     }
-    if (!is_paired)
+    if (is_update)
+    {
+        status = luaL_dostring(L_global, "frame.display.text('Frame Update', 200, 140);"
+                                       "frame.display.show();");
+    }
+    else if (!is_paired)
     {
          status = luaL_dostring(L_global, "frame.display.text('Ready to Pair', 200, 140);"
                                       "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'GREEN' });"
@@ -155,7 +160,7 @@ void run_lua(bool is_paired)
     }
 
     // Show splash screen
-    status = show_pairing_screen(is_paired);
+    status = show_pairing_screen(is_paired, false);
 
 
     //  Run REPL

--- a/source/application/luaport.c
+++ b/source/application/luaport.c
@@ -75,22 +75,20 @@ int show_pairing_screen(bool is_paired)
          status = luaL_dostring(L_global, "frame.display.text('Ready to Pair', 200, 140);"
                                       "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'GREEN' });"
                                       "frame.display.show();");
-        return status;
     }
     else
     {
          status = luaL_dostring(L_global, "frame.display.text('Frame is Paired', 185, 140);"
                                       "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'ORANGE' });"
                                       "frame.display.show();");
-        return status;
     }
-
 
     if (status != LUA_OK)
     {
         lua_pop(L_global, -1);
         error();
     }
+    return status;
 }
 
 void run_lua(bool is_paired)

--- a/source/application/luaport.c
+++ b/source/application/luaport.c
@@ -63,6 +63,36 @@ void lua_break_signal_interrupt(void)
                 1);
 }
 
+int show_pairing_screen(bool is_paired)
+{
+    int status;
+    if(L_global == NULL)
+    {
+        return LUA_ERRRUN;
+    }
+    if (!is_paired)
+    {
+         status = luaL_dostring(L_global, "frame.display.text('Ready to Pair', 200, 140);"
+                                      "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'GREEN' });"
+                                      "frame.display.show();");
+        return status;
+    }
+    else
+    {
+         status = luaL_dostring(L_global, "frame.display.text('Frame is Paired', 185, 140);"
+                                      "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'ORANGE' });"
+                                      "frame.display.show();");
+        return status;
+    }
+
+
+    if (status != LUA_OK)
+    {
+        lua_pop(L_global, -1);
+        error();
+    }
+}
+
 void run_lua(bool is_paired)
 {
     lua_State *L = luaL_newstate();
@@ -127,24 +157,8 @@ void run_lua(bool is_paired)
     }
 
     // Show splash screen
-    if (!is_paired)
-    {
-        status = luaL_dostring(L, "frame.display.text('Ready to Pair', 200, 140);"
-                                  "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'GREEN' });"
-                                  "frame.display.show();");
-    }
-    else
-    {
-        status = luaL_dostring(L, "frame.display.text('Frame is Paired', 185, 140);"
-                                  "frame.display.text('Frame '..frame.bluetooth.address():sub(-2, -1), 245, 210, { color = 'ORANGE' });"
-                                  "frame.display.show();");
-    }
+    status = show_pairing_screen(is_paired);
 
-    if (status != LUA_OK)
-    {
-        lua_pop(L, -1);
-        error();
-    }
 
     //  Run REPL
     while (true)

--- a/source/application/luaport.h
+++ b/source/application/luaport.h
@@ -40,4 +40,4 @@ void lua_break_signal_interrupt(void);
 
 void run_lua(bool is_paired);
 
-int show_pairing_screen(bool is_paired);
+int show_pairing_screen(bool is_paired, bool is_update);

--- a/source/application/luaport.h
+++ b/source/application/luaport.h
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include "bluetooth.h"
 #include "nrfx_log.h"
-
+#include "lua.h"
 #define lua_writestring(s, l) bluetooth_send_data((uint8_t *)s, l)
 #define lua_writeline()
 #define lua_writestringerror(s, p) printf(s, p)
@@ -39,3 +39,5 @@ void lua_write_to_repl(uint8_t *buffer, uint8_t length);
 void lua_break_signal_interrupt(void);
 
 void run_lua(bool is_paired);
+
+int show_pairing_screen(bool is_paired);

--- a/source/application/main.c
+++ b/source/application/main.c
@@ -331,7 +331,7 @@ static void hardware_setup()
             {
                 LOG("Factory reset");
                 bluetooth_unpair();
-                stay_awake = true;
+                // stay_awake = true;
             }
         }
 

--- a/source/application/main.c
+++ b/source/application/main.c
@@ -331,7 +331,7 @@ static void hardware_setup()
             {
                 LOG("Factory reset");
                 bluetooth_unpair();
-                // stay_awake = true;
+                stay_awake = true;
             }
         }
 


### PR DESCRIPTION
After pairing display was not updated to show frame is paired  without reset,
this fixes by updating info after  pair.

Fixes https://github.com/brilliantlabsAR/frame-codebase/issues/289